### PR TITLE
Added option to use external nose python modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,11 @@ Type: `String`
 
 Run the unit tests in this virtualenv.
 
+#### externalNose
+Type: `Boolean`  
+
+Use nose modules from python interpreter in path.
+
 #### with_xunit
 Type: `Boolean`  
 Default: false

--- a/tasks/nose.js
+++ b/tasks/nose.js
@@ -58,16 +58,24 @@ module.exports = function(grunt) {
       grunt.log.verbose.writeln("Using virtualenv at " + options.virtualenv);
       delete options.virtualenv;
     }
+    
+    var pythonCode = [];  
+      
+    var externalNose = options.externalNose;
+    delete options.externalNose;
 
+    pythonCode.push('import sys');
+      
+    if (!externalNose) {
+      pythonCode.push('sys.path.insert(0, r"'+path.join(__dirname, 'lib')+'")');
+
+    }
+
+    pythonCode.push(virtualenv, 'from nose.core import run_exit', 'run_exit()');
+      
     var baseArgs = [
       '-c',
-      [
-        'import sys',
-        'sys.path.insert(0, r"'+path.join(__dirname, 'lib')+'")',
-        virtualenv,
-        'from nose.core import run_exit',
-        'run_exit()'
-      ].join('; ')
+      pythonCode.join('; ')
     ];
 
     // Set the nose 'where' option for each of the files specified for the task


### PR DESCRIPTION
This is the code without any tests. Shall I try to port them too? You mentioned, that you're still looking for a better way to test this.
