### PR TITLE
remove repeated virtualenv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,6 @@ grunt.initConfig({
       cover_xml: true,
       coverage_html: true,
       coverage_html_dir: 'code_coverage',
-      virtualenv: 'my_app_venv',
       with_doctest: true,
       with_xunit: true,
     },


### PR DESCRIPTION
I noticed while looking over the README.md that this `virtualenv` key is a duplicate.
