### PR TITLE
Remove peerDependency on old version of grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "load-grunt-tasks": "~3.1.0",
     "xml2js": "~0.4.5"
   },
-  "peerDependencies": {
-    "grunt": ">=0.4.0"
-  },
   "keywords": [
     "gruntplugin",
     "nose",


### PR DESCRIPTION
It causes warnings while installing this package, and shouldn't be necessary: Ref https://github.com/gruntjs/grunt/issues/1537#issuecomment-235324836